### PR TITLE
Added support to sourcemaps

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ function jsHint(input, options) {
 		throw new Error("Module failed in cause of jshint error.");
 }
 
-module.exports = function(input) {
+module.exports = function(input, map) {
 	this.cacheable && this.cacheable();
 	var callback = this.async();
 
@@ -148,7 +148,7 @@ module.exports = function(input) {
 		catch(e) {
 			return callback(e);
 		}
-		callback(null, input);
+		callback(null, input, map);
 
 	}.bind(this));
 }


### PR DESCRIPTION
I simply added the support to sourcemaps.
It is very useful if you want to use jshint on files that are transformed.

For example with .jsx files loaded with the jsx-loader, which creates the sourcemap relative to the original jsx files (before they are transformed).