### PR TITLE
An empty .jshintrc file causes options to be undefined, which throws a cryptic error

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function loadRcConfig(callback){
 						options = JSON.parse(stripJsonComments(file));
 					}
 					catch(e) {
-						err = e;
+						err = new Error("Can't parse config file: " + path);
 					}
 				}
 				callback(err, options);


### PR DESCRIPTION
An empty .jshintrc file causes options to be undefined, which throws a cryptic error:

```
ERROR in ./app.js
Module build failed: SyntaxError: Unexpected end of input
    at Object.parse (native)
    at C:\Users\Luke\Documents\Websites\Node\ps-webpack\node_modules\jshint-loader\index.js:46:22
    at tryToString (fs.js:414:3)
    at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:401:12)
```

There were two ways I thought about handling the case of an empty .jshintrc file:  throwing a different error or setting the file to contain only empty curly braces.  I did the latter.  However, if the .jshintrc file contains nothing but comments, then the options variable will still get set to undefined after comments are stripped.  So, I also added a new error.

If the options variable can be undefined under any other circumstances, then this is not a good solution since it assumes the only time options are undefined is if the .jshintrc file is either empty or contains nothing but comments.  I'm not sure if that is actually the case.